### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pod 'JSONSyntaxHighlight'
 Example
 -------
 
-Clone this repository and open the XCode project to see the Mac and iOS examples
+Clone this repository and open the Xcode project to see the Mac and iOS examples
 
 Import this library
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
